### PR TITLE
Добавлены ручные тесты для проверки коллизий в игре Pacman.

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -8,6 +8,7 @@ using Color = System.Drawing.Color;
 using Timer = System.Windows.Forms.Timer;
 using MessageBox = System.Windows.Forms.MessageBox;
 using Size = System.Drawing.Size;
+using PACMAN_GAME.tests; 
 
 namespace PACMAN_GAME;
 
@@ -1885,6 +1886,12 @@ public partial class Form1 : Form
         
         KeyDown += Form1_KeyDown;
         KeyUp += Form1_KeyUp;
+
+       
+        var tests = new ManualCollisionTests();
+        tests.TestPacmanCollidesWithGhost();
+        tests.TestPacmanCollidesWithWall();
+        tests.TestPacmanCollidesWithCoin();
     }
     
     /// <summary>

--- a/tests/CollisionDetection.cs
+++ b/tests/CollisionDetection.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using PACMAN_GAME;
+
+namespace PACMAN_GAME.tests
+{
+    // Простая заглушка для ISoundManager
+    public class DummySoundManager : ISoundManager
+    {
+        public Dictionary<string, System.Windows.Media.MediaPlayer> _sounds_pub => new();
+        public void InitializeSounds() { }
+        public bool IsPlaying(string soundName) => false;
+        public void PlaySound(string soundName) { }
+        public void StopAllSounds() { }
+        public void StopSound(string soundName) { }
+    }
+
+    public class ManualCollisionTests
+    {
+        public void TestPacmanCollidesWithGhost()
+        {
+            var soundManager = new DummySoundManager();
+            var collisionHandler = new CollisionHandler(soundManager);
+            var pacmanView = new PictureBox { Bounds = new Rectangle(10, 10, 30, 30) };
+            var ghostView = new PictureBox { Bounds = new Rectangle(20, 20, 30, 30) };
+            var pacman = new Pacman(pacmanView, new Form(), soundManager);
+            var ghost = new RedGhost(ghostView, new Form());
+            bool collision = collisionHandler.CheckCollision(pacman, ghost);
+            if (collision)
+                Console.WriteLine("[OK] Pacman vs Ghost: Столкновение обнаружено");
+            else
+                Console.WriteLine("[FAIL] Pacman vs Ghost: Столкновение не обнаружено");
+        }
+
+        public void TestPacmanCollidesWithWall()
+        {
+            var soundManager = new DummySoundManager();
+            var collisionHandler = new CollisionHandler(soundManager);
+            var pacmanView = new PictureBox { Bounds = new Rectangle(50, 50, 30, 30) };
+            var wallView = new PictureBox { Bounds = new Rectangle(60, 60, 30, 30) };
+            var pacman = new Pacman(pacmanView, new Form(), soundManager);
+            var wall = new Wall(wallView);
+            bool collision = collisionHandler.CheckCollision(pacman, wall);
+            if (collision)
+                Console.WriteLine("[OK] Pacman vs Wall: Столкновение обнаружено");
+            else
+                Console.WriteLine("[FAIL] Pacman vs Wall: Столкновение не обнаружено");
+        }
+
+        public void TestPacmanCollidesWithCoin()
+        {
+            var soundManager = new DummySoundManager();
+            var collisionHandler = new CollisionHandler(soundManager);
+            var pacmanView = new PictureBox { Bounds = new Rectangle(100, 100, 30, 30) };
+            var coinView = new PictureBox { Bounds = new Rectangle(110, 110, 10, 10) };
+            var pacman = new Pacman(pacmanView, new Form(), soundManager);
+            var coin = new Coin(coinView);
+            bool collision = collisionHandler.CheckCollision(pacman, coin);
+            if (collision)
+                Console.WriteLine("[OK] Pacman vs Coin: Столкновение обнаружено");
+            else
+                Console.WriteLine("[FAIL] Pacman vs Coin: Столкновение не обнаружено");
+        }
+    }
+}


### PR DESCRIPTION
- Реализованы методы тестирования столкновений Pacman с привидением, стеной и монетой. 
- Каждый тест создает необходимые объекты, проверяет факт столкновения и выводит результат в консоль.
![столкновение Pacman и Coin](https://github.com/user-attachments/assets/410517c0-ab20-4f05-ab79-137ac8f28d05)
![столкновение Pacman и Ghost ](https://github.com/user-attachments/assets/a221771d-8e99-4a3f-95de-af00ebfa8ade)
![столкновение Pacman и Wall](https://github.com/user-attachments/assets/eeb3991d-310c-4719-b808-f5c066786a02)
